### PR TITLE
Add platformio configuration.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,18 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[env:default]
+platform = atmelavr
+board = nanoatmega328
+framework = arduino
+


### PR DESCRIPTION
This adds a platformio configuration file.
The configuration file specifies the platform (atmel avr), the target hardware (arduino nano) and the environment framework. This is all that is needed to compile the firmware from the command line, the toolchain (compiler, uploaded utilities etc.) and libraries are downloaded automatically (and cached locally).

With platformio, the firmware can be compiled/built and uploaded to the arduino using simply:
  pio run -t upload

Platformio requires python3 and can be installed as follows (example for Debian Linux):
  sudo apt install python3-pip
  sudo pip3 install platformio